### PR TITLE
Add logout and profile features

### DIFF
--- a/Jobs.html
+++ b/Jobs.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="/logout">Log Out</a>
   </div>
 
   <div class="container">

--- a/Profile.html
+++ b/Profile.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="/logout">Log Out</a>
   </div>
   
   <div class="container">
@@ -20,7 +21,7 @@
     <div class="form-container">
       <form action="/updateProfile" method="post" enctype="multipart/form-data">
         <label for="email">Email:</label>
-        <input type="email" id="email" name="email" required>
+        <input type="email" id="email" name="email" readonly required>
         
         <label for="phone">Phone Number:</label>
         <input type="text" id="phone" name="phone" required>
@@ -48,5 +49,16 @@
   <div class="footer">
     <p>&copy; 2025 THE SQUARE SCREWDRIVER</p>
   </div>
+  <script>
+    fetch('/user').then(r=>r.json()).then(u=>{
+      if(!u.email) return;
+      document.getElementById('email').value = u.email;
+      document.getElementById('phone').value = u.phone || '';
+      document.getElementById('familyPhone').value = u.familyPhone || '';
+      document.getElementById('age').value = u.age || '';
+      document.getElementById('address').value = u.address || '';
+      document.getElementById('idNumber').value = u.idNumber || '';
+    });
+  </script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ This repository contains a simple job portal for drilling platform workers. The 
 4. Visit `http://localhost:3000/index.html` in your browser.
 
 The initial admin account is `admin@example.com`. Any user signed in with this email will be able to access `admin.html` to add job vacancies.
+
+To sign out, visit `/logout` or use the **Log Out** link visible in the navigation bar once you are logged in. Your profile page now automatically loads your saved information.

--- a/admin.html
+++ b/admin.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="/logout">Log Out</a>
   </div>
 
   <div class="container">

--- a/apply.html
+++ b/apply.html
@@ -12,6 +12,7 @@
     <a href="jobs.html">Jobs Available</a>
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
+    <a href="/logout">Log Out</a>
   </div>
 
   <div class="container">

--- a/auth.html
+++ b/auth.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="/logout">Log Out</a>
   </div>
   
   <div class="container">

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="/logout">Log Out</a>
   </div>
   
   <div class="container">

--- a/server.js
+++ b/server.js
@@ -165,4 +165,20 @@ app.post('/apply', cpUpload, (req, res) => {
   res.send('Application submitted');
 });
 
+// Return currently signed in user (without password)
+app.get('/user', authRequired, (req, res) => {
+  const users = loadJson(USERS_FILE);
+  const user = users.find(u => u.email === req.session.user);
+  if (!user) return res.json({});
+  const { password, token, ...data } = user;
+  res.json(data);
+});
+
+// Logout
+app.get('/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.redirect('/auth.html');
+  });
+});
+
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- enable retrieving profile information and prefill profile form
- add logout route to end sessions
- show "Log Out" link on navigation bar
- document logout link and profile autoload in README

## Testing
- `npm install`
- `npm start &` *(checked server output)*

------
https://chatgpt.com/codex/tasks/task_e_686810d6cf50832f967bc982a51fd985