### PR TITLE
Add admin application management and job search

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="applications.html">Applications</a>
     <a href="/logout">Log Out</a>
   </div>
 

--- a/applications.html
+++ b/applications.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Job Applications</title>
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+  <div class="navbar">
+    <a href="index.html">Home</a>
+    <a href="jobs.html">Jobs Available</a>
+    <a href="auth.html">Sign Up / Sign In</a>
+    <a href="profile.html">Profile</a>
+    <a href="admin.html">Admin</a>
+    <a href="applications.html">Applications</a>
+    <a href="/logout">Log Out</a>
+  </div>
+
+  <div class="container">
+    <h1>Job Applications</h1>
+    <table id="apps-table">
+      <thead>
+        <tr>
+          <th>Job</th>
+          <th>Name</th>
+          <th>Phone</th>
+          <th>ID Number</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <div class="footer">
+    <p>&copy; 2025 THE SQUARE SCREWDRIVER</p>
+  </div>
+
+  <script>
+  fetch('/admin/applications-data')
+    .then(r => r.json())
+    .then(data => {
+      const tbody = document.querySelector('#apps-table tbody');
+      data.forEach(app => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${app.jobTitle}</td><td>${app.name}</td><td>${app.phone}</td><td>${app.idNumber}</td>`;
+        tbody.appendChild(tr);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/apply.html
+++ b/apply.html
@@ -12,6 +12,8 @@
     <a href="jobs.html">Jobs Available</a>
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
+    <a href="admin.html">Admin</a>
+    <a href="applications.html">Applications</a>
     <a href="/logout">Log Out</a>
   </div>
 

--- a/auth.html
+++ b/auth.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="applications.html">Applications</a>
     <a href="/logout">Log Out</a>
   </div>
   

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="applications.html">Applications</a>
     <a href="/logout">Log Out</a>
   </div>
   

--- a/jobs.html
+++ b/jobs.html
@@ -13,11 +13,13 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="applications.html">Applications</a>
     <a href="/logout">Log Out</a>
   </div>
 
   <div class="container">
     <h1>Jobs Available</h1>
+    <input type="text" id="search" placeholder="Search jobs">
     <table id="jobs-table">
       <thead>
         <tr>
@@ -36,13 +38,30 @@
     <p>&copy; 2025 THE SQUARE SCREWDRIVER</p>
   </div>
 <script>
-fetch('/jobs-data').then(r=>r.json()).then(data=>{
-  const tbody = document.querySelector('#jobs-table tbody');
-  data.forEach(job=>{
+const tbody = document.querySelector('#jobs-table tbody');
+let jobsData = [];
+function render(list) {
+  tbody.innerHTML = '';
+  list.forEach(job => {
     const tr = document.createElement('tr');
     tr.innerHTML = `<td>${job.title}</td><td>${job.location}</td><td>${job.type}</td><td>${job.description}</td><td><a href="apply.html?jobId=${job.id}">Apply</a></td>`;
     tbody.appendChild(tr);
   });
+}
+
+fetch('/jobs-data').then(r=>r.json()).then(data=>{
+  jobsData = data;
+  render(jobsData);
+});
+
+document.getElementById('search').addEventListener('input', e => {
+  const q = e.target.value.toLowerCase();
+  render(jobsData.filter(job =>
+    job.title.toLowerCase().includes(q) ||
+    job.location.toLowerCase().includes(q) ||
+    job.description.toLowerCase().includes(q) ||
+    job.type.toLowerCase().includes(q)
+  ));
 });
 </script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -13,6 +13,7 @@
     <a href="auth.html">Sign Up / Sign In</a>
     <a href="profile.html">Profile</a>
     <a href="admin.html">Admin</a>
+    <a href="applications.html">Applications</a>
     <a href="/logout">Log Out</a>
   </div>
   

--- a/server.js
+++ b/server.js
@@ -144,6 +144,17 @@ app.get('/jobs-data', (req, res) => {
   res.json(loadJson(JOBS_FILE));
 });
 
+// Applications listing for admin
+app.get('/admin/applications-data', adminRequired, (req, res) => {
+  const apps = loadJson(APPS_FILE);
+  const jobs = loadJson(JOBS_FILE);
+  const withTitle = apps.map(a => ({
+    ...a,
+    jobTitle: (jobs.find(j => j.id === a.jobId) || {}).title || 'N/A'
+  }));
+  res.json(withTitle);
+});
+
 // Job application form submission
 const cpUpload = upload.fields([
   { name: 'idCard', maxCount: 1 },


### PR DESCRIPTION
## Summary
- allow admins to view submitted applications via new `applications.html`
- expose `/admin/applications-data` endpoint
- add search field for jobs page
- update navigation menus

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_686c20525770832f914d0292003edc30